### PR TITLE
Add support for WHERE column conditions in query builder

### DIFF
--- a/internal/common/structs/query.go
+++ b/internal/common/structs/query.go
@@ -11,12 +11,13 @@ type Table struct {
 }
 
 type Where struct {
-	Column    string
-	Condition string
-	Value     []interface{}
-	Operator  int
-	Query     *Query
-	Raw       string
+	Column      string
+	Condition   string
+	Value       []interface{}
+	ValueColumn string
+	Operator    int
+	Query       *Query
+	Raw         string
 }
 
 type WhereGroup struct {

--- a/internal/db/where_base.go
+++ b/internal/db/where_base.go
@@ -118,7 +118,9 @@ func (wb *WhereBaseBuilder) Where(sb *strings.Builder, wg *[]structs.WhereGroup)
 					wsb.WriteString(raw)
 				} else {
 					wsb.WriteString(convertedColumn + " " + c.Condition)
-					if c.Value != nil {
+					if c.ValueColumn != "" {
+						wsb.WriteString(" " + c.ValueColumn)
+					} else if c.Value != nil {
 						if len(c.Value) > 1 {
 							wsb.WriteString(" (")
 							for k := 0; k < len(c.Value); k++ {

--- a/pkg/api/wherequerybuidler.go
+++ b/pkg/api/wherequerybuidler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"github.com/faciam-dev/goquent-query-builder/internal/cache"
+	"github.com/faciam-dev/goquent-query-builder/internal/common/consts"
 	"github.com/faciam-dev/goquent-query-builder/internal/db"
 	"github.com/faciam-dev/goquent-query-builder/internal/query"
 )
@@ -183,5 +184,45 @@ func (wb *WhereQueryBuilder[T, C]) OrWhereNull(column string) *T {
 
 func (wb *WhereQueryBuilder[T, C]) OrWhereNotNull(column string) *T {
 	wb.builder.OrWhereNotNull(column)
+	return wb.parent
+}
+
+func (wb *WhereQueryBuilder[T, C]) WhereColumn(allColumns []string, column string, cond ...string) *T {
+	operator := consts.Condition_EQUAL
+	valueColumn := column
+	if len(cond) > 0 {
+		valueColumn = cond[0]
+	}
+	if len(cond) > 1 {
+		operator = cond[0]
+		valueColumn = cond[1]
+	}
+
+	wb.builder.WhereColumn(allColumns, column, operator, valueColumn)
+	return wb.parent
+}
+
+func (wb *WhereQueryBuilder[T, C]) OrWhereColumn(allColumns []string, column string, cond ...string) *T {
+	operator := consts.Condition_EQUAL
+	valueColumn := column
+	if len(cond) > 0 {
+		valueColumn = cond[0]
+	}
+	if len(cond) > 1 {
+		operator = cond[0]
+		valueColumn = cond[1]
+	}
+
+	wb.builder.OrWhereColumn(allColumns, column, operator, valueColumn)
+	return wb.parent
+}
+
+func (wb *WhereQueryBuilder[T, C]) WhereColumns(allColumns []string, columns [][]string) *T {
+	wb.builder.WhereColumns(allColumns, columns)
+	return wb.parent
+}
+
+func (wb *WhereQueryBuilder[T, C]) OrWhereColumns(allColumns []string, columns [][]string) *T {
+	wb.builder.OrWhereColumns(allColumns, columns)
 	return wb.parent
 }

--- a/tests/db/base_test.go
+++ b/tests/db/base_test.go
@@ -355,6 +355,51 @@ func TestBaseQueryBuilder(t *testing.T) {
 			},
 		},
 		{
+			"WhereNull",
+			"Where",
+			structs.Query{
+				ConditionGroups: &[]structs.WhereGroup{
+					{
+						Conditions: []structs.Where{
+							{
+								Column:    "name",
+								Condition: "IS NULL",
+								Operator:  consts.LogicalOperator_AND,
+							},
+						},
+						IsDummyGroup: true,
+					},
+				},
+			},
+			QueryBuilderExpected{
+				Expected: " WHERE name IS NULL",
+				Values:   nil,
+			},
+		},
+		{
+			"WhereColumn",
+			"Where",
+			structs.Query{
+				ConditionGroups: &[]structs.WhereGroup{
+					{
+						Conditions: []structs.Where{
+							{
+								Column:      "name",
+								Condition:   "=",
+								ValueColumn: "users.name",
+								Operator:    consts.LogicalOperator_AND,
+							},
+						},
+						IsDummyGroup: true,
+					},
+				},
+			},
+			QueryBuilderExpected{
+				Expected: " WHERE name = users.name",
+				Values:   nil,
+			},
+		},
+		{
 			"Join",
 			"Join",
 			structs.Query{

--- a/tests/query/builder_test.go
+++ b/tests/query/builder_test.go
@@ -619,6 +619,54 @@ func TestWhereSelectBuilder(t *testing.T) {
 			"SELECT  FROM  WHERE age > ? OR deleted_at IS NOT NULL",
 			[]interface{}{18},
 		},
+		{
+			"WhereColumn",
+			func() *query.Builder {
+				return query.NewBuilder(db.NewMySQLQueryBuilder(), cache.NewAsyncQueryCache(100)).WhereColumn([]string{"created_at", "updated_at", "deleted_at"}, "created_at", "=", "updated_at")
+			},
+			"SELECT  FROM  WHERE created_at = updated_at",
+			nil,
+		},
+		{
+			"WhereColumn_With_Operator",
+			func() *query.Builder {
+				return query.NewBuilder(db.NewMySQLQueryBuilder(), cache.NewAsyncQueryCache(100)).WhereColumn([]string{"created_at", "updated_at", "deleted_at"}, "created_at", ">", "updated_at")
+			},
+			"SELECT  FROM  WHERE created_at > updated_at",
+			nil,
+		},
+		{
+			"OrWhereColumn",
+			func() *query.Builder {
+				return query.NewBuilder(db.NewMySQLQueryBuilder(), cache.NewAsyncQueryCache(100)).Where("age", ">", 18).OrWhereColumn([]string{"created_at", "updated_at", "deleted_at"}, "created_at", "=", "updated_at")
+			},
+			"SELECT  FROM  WHERE age > ? OR created_at = updated_at",
+			[]interface{}{18},
+		},
+		{
+			"OrWhereColumn_With_Operator",
+			func() *query.Builder {
+				return query.NewBuilder(db.NewMySQLQueryBuilder(), cache.NewAsyncQueryCache(100)).Where("age", ">", 18).OrWhereColumn([]string{"created_at", "updated_at", "deleted_at"}, "created_at", ">", "updated_at")
+			},
+			"SELECT  FROM  WHERE age > ? OR created_at > updated_at",
+			[]interface{}{18},
+		},
+		{
+			"WhereColumns",
+			func() *query.Builder {
+				return query.NewBuilder(db.NewMySQLQueryBuilder(), cache.NewAsyncQueryCache(100)).WhereColumns([]string{"created_at", "updated_at", "deleted_at"}, [][]string{{"created_at", "=", "updated_at"}, {"deleted_at", "=", "updated_at"}})
+			},
+			"SELECT  FROM  WHERE created_at = updated_at AND deleted_at = updated_at",
+			nil,
+		},
+		{
+			"OrWhereColumns",
+			func() *query.Builder {
+				return query.NewBuilder(db.NewMySQLQueryBuilder(), cache.NewAsyncQueryCache(100)).OrWhereColumns([]string{"created_at", "updated_at", "deleted_at"}, [][]string{{"created_at", "=", "updated_at"}, {"deleted_at", "=", "updated_at"}})
+			},
+			"SELECT  FROM  WHERE created_at = updated_at OR deleted_at = updated_at",
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tests/query/delete_builder_test.go
+++ b/tests/query/delete_builder_test.go
@@ -107,6 +107,28 @@ func TestDeleteBuilder(t *testing.T) {
 			[]interface{}{},
 		},
 		{
+			"Delete_where_not_null",
+			func() *query.DeleteBuilder {
+				return query.NewDeleteBuilder(&db.MySQLQueryBuilder{}, cache.NewAsyncQueryCache(100)).
+					Table("users").
+					WhereNotNull("name").
+					Delete()
+			},
+			"DELETE FROM users WHERE name IS NOT NULL",
+			[]interface{}{},
+		},
+		{
+			"Delete_where_column",
+			func() *query.DeleteBuilder {
+				return query.NewDeleteBuilder(&db.MySQLQueryBuilder{}, cache.NewAsyncQueryCache(100)).
+					Table("users").
+					WhereColumn([]string{"name", "note"}, "name", "=", "note").
+					Delete()
+			},
+			"DELETE FROM users WHERE name = note",
+			[]interface{}{},
+		},
+		{
 			"Delete_JOINS",
 			func() *query.DeleteBuilder {
 				return query.NewDeleteBuilder(&db.MySQLQueryBuilder{}, cache.NewAsyncQueryCache(100)).

--- a/tests/query/update_builder_test.go
+++ b/tests/query/update_builder_test.go
@@ -104,6 +104,34 @@ func TestUpdateBuilder(t *testing.T) {
 			[]interface{}{31, "Joe"},
 		},
 		{
+			"Update_where_column",
+			func() *query.UpdateBuilder {
+				return query.NewUpdateBuilder(&db.MySQLQueryBuilder{}, cache.NewAsyncQueryCache(100)).
+					Table("users").
+					WhereColumn([]string{"name", "note"}, "name", "=", "note").
+					Update(map[string]interface{}{
+						"name": "Joe",
+						"age":  31,
+					})
+			},
+			"UPDATE users SET age = ?, name = ? WHERE name = note",
+			[]interface{}{31, "Joe"},
+		},
+		{
+			"Update_where_or_columns",
+			func() *query.UpdateBuilder {
+				return query.NewUpdateBuilder(&db.MySQLQueryBuilder{}, cache.NewAsyncQueryCache(100)).
+					Table("users").
+					OrWhereColumns([]string{"name", "nick_name", "memo", "note"}, [][]string{{"name", "=", "nick_name"}, {"memo", "=", "note"}}).
+					Update(map[string]interface{}{
+						"name": "Joe",
+						"age":  31,
+					})
+			},
+			"UPDATE users SET age = ?, name = ? WHERE name = nick_name OR memo = note",
+			[]interface{}{31, "Joe"},
+		},
+		{
 			"Update_JOINS",
 			func() *query.UpdateBuilder {
 				return query.NewUpdateBuilder(&db.MySQLQueryBuilder{}, cache.NewAsyncQueryCache(100)).


### PR DESCRIPTION
# Summary
Add support for WHERE column conditions in query builder

# Issue
#14 

# Detail
- whereColumn／orWhereColumn
- As a measure against SQL injection, always use a whitelist(1st arg) for safety.
