### PR TITLE
Add upsert and ignore insert features

### DIFF
--- a/api/insert_querybuilder.go
+++ b/api/insert_querybuilder.go
@@ -30,6 +30,21 @@ func (ib *InsertQueryBuilder) InsertBatch(data []map[string]interface{}) *Insert
 	return ib
 }
 
+func (ib *InsertQueryBuilder) InsertOrIgnore(data []map[string]interface{}) *InsertQueryBuilder {
+	ib.builder.InsertOrIgnore(data)
+	return ib
+}
+
+func (ib *InsertQueryBuilder) Upsert(data []map[string]interface{}, unique []string, updateColumns []string) *InsertQueryBuilder {
+	ib.builder.Upsert(data, unique, updateColumns)
+	return ib
+}
+
+func (ib *InsertQueryBuilder) UpdateOrInsert(condition map[string]interface{}, values map[string]interface{}) *InsertQueryBuilder {
+	ib.builder.UpdateOrInsert(condition, values)
+	return ib
+}
+
 func (ib *InsertQueryBuilder) InsertUsing(columns []string, qb *SelectQueryBuilder) *InsertQueryBuilder {
 	ib.builder.InsertUsing(columns, qb.builder)
 	return ib

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -33,6 +33,14 @@ func NewMySQLQueryBuilder() *MySQLQueryBuilder {
 	return queryBuilder
 }
 
+func (m MySQLQueryBuilder) InsertIgnore(q *structs.InsertQuery) (string, []interface{}, error) {
+	return m.InsertBaseBuilder.InsertIgnore(q)
+}
+
+func (m MySQLQueryBuilder) Upsert(q *structs.InsertQuery) (string, []interface{}, error) {
+	return m.InsertBaseBuilder.Upsert(q)
+}
+
 // Build builds the query.
 func (m MySQLQueryBuilder) Build(sb *[]byte, q *structs.Query, number int, unions *[]structs.Union) ([]interface{}, error) {
 	// SELECT

--- a/database/mysql/utils.go
+++ b/database/mysql/utils.go
@@ -42,6 +42,10 @@ func (s *SQLUtils) GetQueryBuilderStrategy() interfaces.QueryBuilderStrategy {
 	return NewMySQLQueryBuilder()
 }
 
+func (s *SQLUtils) Dialect() string {
+	return "mysql"
+}
+
 func (s *SQLUtils) EscapeIdentifier(sb []byte, v string) []byte {
 	if v != "*" {
 		if eoc := strings.IndexByte(v, '.'); eoc != -1 {

--- a/database/mysql/utils.go
+++ b/database/mysql/utils.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"strings"
 
+	"github.com/faciam-dev/goquent-query-builder/internal/common/consts"
 	"github.com/faciam-dev/goquent-query-builder/internal/db/interfaces"
 )
 
@@ -43,7 +44,7 @@ func (s *SQLUtils) GetQueryBuilderStrategy() interfaces.QueryBuilderStrategy {
 }
 
 func (s *SQLUtils) Dialect() string {
-	return "mysql"
+	return consts.DialectMySQL
 }
 
 func (s *SQLUtils) EscapeIdentifier(sb []byte, v string) []byte {

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -33,6 +33,14 @@ func NewPostgreSQLQueryBuilder() *PostgreSQLQueryBuilder {
 	return queryBuilder
 }
 
+func (m PostgreSQLQueryBuilder) InsertIgnore(q *structs.InsertQuery) (string, []interface{}, error) {
+	return m.InsertBaseBuilder.InsertIgnore(q)
+}
+
+func (m PostgreSQLQueryBuilder) Upsert(q *structs.InsertQuery) (string, []interface{}, error) {
+	return m.InsertBaseBuilder.Upsert(q)
+}
+
 // Build builds the query.
 func (m PostgreSQLQueryBuilder) Build(sb *[]byte, q *structs.Query, number int, unions *[]structs.Union) ([]interface{}, error) {
 	// SELECT

--- a/database/postgres/utils.go
+++ b/database/postgres/utils.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/faciam-dev/goquent-query-builder/internal/common/consts"
 	"github.com/faciam-dev/goquent-query-builder/internal/db/interfaces"
 )
 
@@ -70,7 +71,7 @@ func (s *SQLUtils) GetQueryBuilderStrategy() interfaces.QueryBuilderStrategy {
 }
 
 func (s *SQLUtils) Dialect() string {
-	return "postgres"
+	return consts.DialectPostgreSQL
 }
 
 func (s *SQLUtils) EscapeIdentifier(sb []byte, v string) []byte {

--- a/database/postgres/utils.go
+++ b/database/postgres/utils.go
@@ -69,6 +69,10 @@ func (s *SQLUtils) GetQueryBuilderStrategy() interfaces.QueryBuilderStrategy {
 	return NewPostgreSQLQueryBuilder()
 }
 
+func (s *SQLUtils) Dialect() string {
+	return "postgres"
+}
+
 func (s *SQLUtils) EscapeIdentifier(sb []byte, v string) []byte {
 	if v != "*" {
 		if eoc := strings.Index(v, "."); eoc != -1 {

--- a/internal/common/consts/query.go
+++ b/internal/common/consts/query.go
@@ -69,3 +69,9 @@ const (
 	StringBuffer_Update_Grow = 128
 	StringBuffer_Delete_Grow = 128
 )
+
+const (
+	DialectBase       = "base"
+	DialectMySQL      = "mysql"
+	DialectPostgreSQL = "postgres"
+)

--- a/internal/common/structs/query.go
+++ b/internal/common/structs/query.go
@@ -93,6 +93,13 @@ type InsertQuery struct {
 	ValuesBatch []map[string]interface{}
 	Columns     []string
 	Query       *Query
+	Ignore      bool
+	Upsert      *Upsert
+}
+
+type Upsert struct {
+	UniqueColumns []string
+	UpdateColumns []string
 }
 
 type UpdateQuery struct {

--- a/internal/db/base/insert_base.go
+++ b/internal/db/base/insert_base.go
@@ -92,9 +92,9 @@ func (m InsertBaseBuilder) InsertIgnore(q *structs.InsertQuery) (string, []inter
 		return "", nil, err
 	}
 
-	if m.u.Dialect() == "mysql" {
+	if m.u.Dialect() == consts.DialectMySQL {
 		query = strings.Replace(query, "INSERT INTO", "INSERT IGNORE INTO", 1)
-	} else if m.u.Dialect() == "postgres" {
+	} else if m.u.Dialect() == consts.DialectPostgreSQL {
 		query += " ON CONFLICT DO NOTHING"
 	}
 
@@ -241,7 +241,7 @@ func (m InsertBaseBuilder) Upsert(q *structs.InsertQuery) (string, []interface{}
 
 	sb := []byte(baseQuery)
 
-	if m.u.Dialect() == "mysql" {
+	if m.u.Dialect() == consts.DialectMySQL {
 		sb = append(sb, []byte(" ON DUPLICATE KEY UPDATE ")...)
 		for i, col := range q.Upsert.UpdateColumns {
 			if i > 0 {
@@ -252,7 +252,7 @@ func (m InsertBaseBuilder) Upsert(q *structs.InsertQuery) (string, []interface{}
 			sb = m.u.EscapeIdentifier(sb, col)
 			sb = append(sb, []byte(")")...)
 		}
-	} else if m.u.Dialect() == "postgres" {
+	} else if m.u.Dialect() == consts.DialectPostgreSQL {
 		sb = append(sb, []byte(" ON CONFLICT (")...)
 		for i, col := range q.Upsert.UniqueColumns {
 			if i > 0 {
@@ -287,9 +287,9 @@ func (m InsertBaseBuilder) BuildInsert(q *structs.InsertQuery) (string, []interf
 			if err != nil {
 				return "", nil, err
 			}
-			if m.u.Dialect() == "mysql" {
+			if m.u.Dialect() == consts.DialectMySQL {
 				query = strings.Replace(query, "INSERT INTO", "INSERT IGNORE INTO", 1)
-			} else if m.u.Dialect() == "postgres" {
+			} else if m.u.Dialect() == consts.DialectPostgreSQL {
 				query += " ON CONFLICT DO NOTHING"
 			}
 			return query, values, nil

--- a/internal/db/base/insert_base.go
+++ b/internal/db/base/insert_base.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/faciam-dev/goquent-query-builder/internal/common/consts"
@@ -81,6 +82,21 @@ func (m InsertBaseBuilder) Insert(q *structs.InsertQuery) (string, []interface{}
 
 	*ptr = sb
 	poolBytes.Put(ptr)
+
+	return query, values, nil
+}
+
+func (m InsertBaseBuilder) InsertIgnore(q *structs.InsertQuery) (string, []interface{}, error) {
+	query, values, err := m.Insert(q)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if m.u.Dialect() == "mysql" {
+		query = strings.Replace(query, "INSERT INTO", "INSERT IGNORE INTO", 1)
+	} else if m.u.Dialect() == "postgres" {
+		query += " ON CONFLICT DO NOTHING"
+	}
 
 	return query, values, nil
 }
@@ -212,13 +228,80 @@ func (m *InsertBaseBuilder) InsertUsing(q *structs.InsertQuery) (string, []inter
 	return query, selectValues, nil
 }
 
+func (m InsertBaseBuilder) Upsert(q *structs.InsertQuery) (string, []interface{}, error) {
+	// ensure ValuesBatch is set
+	if len(q.ValuesBatch) == 0 && len(q.Values) > 0 {
+		q.ValuesBatch = []map[string]interface{}{q.Values}
+	}
+
+	baseQuery, values, err := m.InsertBatch(q)
+	if err != nil {
+		return "", nil, err
+	}
+
+	sb := []byte(baseQuery)
+
+	if m.u.Dialect() == "mysql" {
+		sb = append(sb, []byte(" ON DUPLICATE KEY UPDATE ")...)
+		for i, col := range q.Upsert.UpdateColumns {
+			if i > 0 {
+				sb = append(sb, []byte(", ")...)
+			}
+			sb = m.u.EscapeIdentifier(sb, col)
+			sb = append(sb, []byte(" = VALUES(")...)
+			sb = m.u.EscapeIdentifier(sb, col)
+			sb = append(sb, []byte(")")...)
+		}
+	} else if m.u.Dialect() == "postgres" {
+		sb = append(sb, []byte(" ON CONFLICT (")...)
+		for i, col := range q.Upsert.UniqueColumns {
+			if i > 0 {
+				sb = append(sb, []byte(", ")...)
+			}
+			sb = m.u.EscapeIdentifier(sb, col)
+		}
+		sb = append(sb, []byte(") DO UPDATE SET ")...)
+		for i, col := range q.Upsert.UpdateColumns {
+			if i > 0 {
+				sb = append(sb, []byte(", ")...)
+			}
+			sb = m.u.EscapeIdentifier(sb, col)
+			sb = append(sb, []byte(" = EXCLUDED.")...)
+			sb = m.u.EscapeIdentifier(sb, col)
+		}
+	}
+
+	return string(sb), values, nil
+}
+
 // BuildInsert builds the INSERT query.
 func (m InsertBaseBuilder) BuildInsert(q *structs.InsertQuery) (string, []interface{}, error) {
+	if q.Upsert != nil {
+		return m.Upsert(q)
+	}
+
+	if q.Ignore {
+		if len(q.ValuesBatch) > 0 {
+			// treat as single batch but with ignore
+			query, values, err := m.InsertBatch(q)
+			if err != nil {
+				return "", nil, err
+			}
+			if m.u.Dialect() == "mysql" {
+				query = strings.Replace(query, "INSERT INTO", "INSERT IGNORE INTO", 1)
+			} else if m.u.Dialect() == "postgres" {
+				query += " ON CONFLICT DO NOTHING"
+			}
+			return query, values, nil
+		}
+		return m.InsertIgnore(q)
+	}
+
 	if q.Query != nil {
 		return m.InsertUsing(q)
 	}
 
-	if len(q.Values) > 0 {
+	if len(q.Values) > 0 && len(q.ValuesBatch) == 0 {
 		return m.Insert(q)
 	}
 

--- a/internal/db/base/utils.go
+++ b/internal/db/base/utils.go
@@ -57,6 +57,10 @@ func (s *SQLUtils) GetQueryBuilderStrategy() interfaces.QueryBuilderStrategy {
 	return NewBaseQueryBuilder()
 }
 
+func (s *SQLUtils) Dialect() string {
+	return "base"
+}
+
 func (s *SQLUtils) EscapeIdentifier(sb []byte, v string) []byte {
 	if v != "*" {
 		if eoc := strings.Index(v, "."); eoc != -1 {

--- a/internal/db/base/utils.go
+++ b/internal/db/base/utils.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/faciam-dev/goquent-query-builder/internal/common/consts"
 	"github.com/faciam-dev/goquent-query-builder/internal/db/interfaces"
 )
 
@@ -58,7 +59,7 @@ func (s *SQLUtils) GetQueryBuilderStrategy() interfaces.QueryBuilderStrategy {
 }
 
 func (s *SQLUtils) Dialect() string {
-	return "base"
+	return consts.DialectBase
 }
 
 func (s *SQLUtils) EscapeIdentifier(sb []byte, v string) []byte {

--- a/internal/db/interfaces/db.go
+++ b/internal/db/interfaces/db.go
@@ -10,6 +10,8 @@ type QueryBuilderStrategy interface {
 	Insert(q *structs.InsertQuery) (string, []interface{}, error)
 	InsertBatch(q *structs.InsertQuery) (string, []interface{}, error)
 	BuildInsert(q *structs.InsertQuery) (string, []interface{}, error)
+	InsertIgnore(q *structs.InsertQuery) (string, []interface{}, error)
+	Upsert(q *structs.InsertQuery) (string, []interface{}, error)
 
 	BuildUpdate(q *structs.UpdateQuery) (string, []interface{}, error)
 

--- a/internal/db/interfaces/sqlutils.go
+++ b/internal/db/interfaces/sqlutils.go
@@ -6,4 +6,5 @@ type SQLUtils interface {
 	EscapeIdentifierAliasedValue(sb []byte, value string) []byte
 	GetAlias(value string) string
 	GetQueryBuilderStrategy() QueryBuilderStrategy
+	Dialect() string
 }

--- a/internal/query/insertbuilder.go
+++ b/internal/query/insertbuilder.go
@@ -34,6 +34,39 @@ func (ib *InsertBuilder) InsertBatch(data []map[string]interface{}) *InsertBuild
 	return ib
 }
 
+func (ib *InsertBuilder) InsertOrIgnore(data []map[string]interface{}) *InsertBuilder {
+	ib.query.ValuesBatch = data
+	ib.query.Ignore = true
+	return ib
+}
+
+func (ib *InsertBuilder) Upsert(data []map[string]interface{}, unique []string, updateColumns []string) *InsertBuilder {
+	ib.query.ValuesBatch = data
+	ib.query.Upsert = &structs.Upsert{UniqueColumns: unique, UpdateColumns: updateColumns}
+	return ib
+}
+
+func (ib *InsertBuilder) UpdateOrInsert(condition map[string]interface{}, values map[string]interface{}) *InsertBuilder {
+	merged := make(map[string]interface{})
+	for k, v := range condition {
+		merged[k] = v
+	}
+	for k, v := range values {
+		merged[k] = v
+	}
+	unique := make([]string, 0, len(condition))
+	for k := range condition {
+		unique = append(unique, k)
+	}
+	updateCols := make([]string, 0, len(values))
+	for k := range values {
+		updateCols = append(updateCols, k)
+	}
+	ib.query.ValuesBatch = []map[string]interface{}{merged}
+	ib.query.Upsert = &structs.Upsert{UniqueColumns: unique, UpdateColumns: updateCols}
+	return ib
+}
+
 func (ib *InsertBuilder) InsertUsing(columns []string, b *SelectBuilder) *InsertBuilder {
 	ib.query.Columns = columns
 

--- a/tests/db/base_insert_test.go
+++ b/tests/db/base_insert_test.go
@@ -114,6 +114,19 @@ func TestBaseInsertQueryBuilder(t *testing.T) {
 				Values:   []interface{}{"Oakland", "San Diego", 99},
 			},
 		},
+		{
+			"UpdateOrInsert",
+			"Upsert",
+			&structs.InsertQuery{
+				Table:       "users",
+				ValuesBatch: []map[string]interface{}{{"email": "john@example.com", "name": "John"}},
+				Upsert:      &structs.Upsert{UniqueColumns: []string{"email"}, UpdateColumns: []string{"name"}},
+			},
+			QueryBuilderExpected{
+				Expected: "INSERT INTO `users` (`email`, `name`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `name` = VALUES(`name`)",
+				Values:   []interface{}{"john@example.com", "John"},
+			},
+		},
 	}
 
 	builder := mysql.NewMySQLQueryBuilder()

--- a/tests/query/insert_builder_test.go
+++ b/tests/query/insert_builder_test.go
@@ -60,7 +60,7 @@ func TestInsertBuilder(t *testing.T) {
 			[]interface{}{18},
 		},
 		{
-			"InsertOrIgnore",
+			"InsertIgnore",
 			func() *query.InsertBuilder {
 				return query.NewInsertBuilder(mysql.NewMySQLQueryBuilder()).
 					Table("users").

--- a/tests/query/insert_builder_test.go
+++ b/tests/query/insert_builder_test.go
@@ -59,6 +59,39 @@ func TestInsertBuilder(t *testing.T) {
 			"INSERT INTO `users` (`name`, `age`) SELECT `name`, `age` FROM `profiles` WHERE `age` > ?",
 			[]interface{}{18},
 		},
+		{
+			"InsertOrIgnore",
+			func() *query.InsertBuilder {
+				return query.NewInsertBuilder(mysql.NewMySQLQueryBuilder()).
+					Table("users").
+					InsertOrIgnore([]map[string]interface{}{
+						{"name": "John", "age": 30},
+					})
+			},
+			"INSERT IGNORE INTO `users` (`age`, `name`) VALUES (?, ?)",
+			[]interface{}{30, "John"},
+		},
+		{
+			"Upsert",
+			func() *query.InsertBuilder {
+				return query.NewInsertBuilder(mysql.NewMySQLQueryBuilder()).
+					Table("flights").
+					Upsert([]map[string]interface{}{{"departure": "Oakland", "destination": "San Diego", "price": 99}},
+						[]string{"departure", "destination"}, []string{"price"})
+			},
+			"INSERT INTO `flights` (`departure`, `destination`, `price`) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE `price` = VALUES(`price`)",
+			[]interface{}{"Oakland", "San Diego", 99},
+		},
+		{
+			"UpdateOrInsert",
+			func() *query.InsertBuilder {
+				return query.NewInsertBuilder(mysql.NewMySQLQueryBuilder()).
+					Table("users").
+					UpdateOrInsert(map[string]interface{}{"email": "john@example.com"}, map[string]interface{}{"name": "John"})
+			},
+			"INSERT INTO `users` (`email`, `name`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `name` = VALUES(`name`)",
+			[]interface{}{"john@example.com", "John"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- support `InsertOrIgnore`, `Upsert`, and `UpdateOrInsert`
- track dialect via SQL utils
- implement insert ignore and upsert logic for MySQL and PostgreSQL
- expose new insert APIs and adjust builders
- add tests covering new insert features

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6853a9297ba083288111361cd729454d