### PR TITLE
Reduce allocations

### DIFF
--- a/internal/db/base/insert_base.go
+++ b/internal/db/base/insert_base.go
@@ -148,18 +148,14 @@ func (m InsertBaseBuilder) InsertBatch(q *structs.InsertQuery) (string, []interf
 	// VALUES
 	estimatedSize := len(q.ValuesBatch) * len(columns)
 	if cap(allValues) < estimatedSize {
-		newAllValue := make([]interface{}, 0, estimatedSize)
-		copy(newAllValue, allValues)
-		allValues = newAllValue
+		allValues = make([]interface{}, 0, estimatedSize)
 	}
 	for i, values := range q.ValuesBatch {
-		rowValues := make([]interface{}, 0, len(columns))
-		for j := range columns {
-			if value, ok := values[columns[j]]; ok {
-				rowValues = rowValues[:len(rowValues)+1]
+		rowValues := make([]interface{}, len(columns))
+		for j, col := range columns {
+			if value, ok := values[col]; ok {
 				rowValues[j] = value
 			} else {
-				rowValues = rowValues[:len(rowValues)+1]
 				rowValues[j] = nil
 			}
 		}

--- a/internal/query/selectbuilder.go
+++ b/internal/query/selectbuilder.go
@@ -296,9 +296,7 @@ func (b *SelectBuilder) Build() (string, []interface{}, error) {
 	}
 	// grow the buffer if necessary
 	if cap(sb) < estimatedSize {
-		newsb := make([]byte, 0, estimatedSize)
-		copy(newsb, sb)
-		sb = newsb
+		sb = make([]byte, 0, estimatedSize)
 	}
 
 	vPtr := interfaceSlicePool.Get().(*[]interface{})


### PR DESCRIPTION
## Summary
- optimize select builder buffer growth
- reuse slice allocations in insert base builder

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6853bf9682308328b2093262bb02d2d5