### PR TITLE
Improve utility performance

### DIFF
--- a/database/postgres/utils.go
+++ b/database/postgres/utils.go
@@ -9,6 +9,8 @@ import (
 	"github.com/faciam-dev/goquent-query-builder/internal/db/interfaces"
 )
 
+var asRegexp = regexp.MustCompile(`(?i)\s+as\s+`)
+
 type SQLUtils struct {
 	placeholderNumber int
 }
@@ -53,9 +55,8 @@ func (s *SQLUtils) EscapeIdentifierAliasedValue(sb []byte, value string) []byte 
 		return sb
 	}
 
-	target := regexp.MustCompile(`(?i)\s+as\s+`)
-	if target.MatchString(value) {
-		parts := target.Split(value, -1)
+	if asRegexp.MatchString(value) {
+		parts := asRegexp.Split(value, -1)
 		sb = s.EscapeIdentifier(sb, parts[0])
 		sb = append(sb, " as "...)
 		sb = s.EscapeIdentifier(sb, parts[1])

--- a/database/postgres/utils.go
+++ b/database/postgres/utils.go
@@ -1,15 +1,13 @@
 package postgres
 
 import (
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/faciam-dev/goquent-query-builder/internal/common/consts"
+	"github.com/faciam-dev/goquent-query-builder/internal/common/sqlutils"
 	"github.com/faciam-dev/goquent-query-builder/internal/db/interfaces"
 )
-
-var asRegexp = regexp.MustCompile(`(?i)\s+as\s+`)
 
 type SQLUtils struct {
 	placeholderNumber int
@@ -55,8 +53,8 @@ func (s *SQLUtils) EscapeIdentifierAliasedValue(sb []byte, value string) []byte 
 		return sb
 	}
 
-	if asRegexp.MatchString(value) {
-		parts := asRegexp.Split(value, -1)
+	if sqlutils.AsRegexp.MatchString(value) {
+		parts := sqlutils.AsRegexp.Split(value, -1)
 		sb = s.EscapeIdentifier(sb, parts[0])
 		sb = append(sb, " as "...)
 		sb = s.EscapeIdentifier(sb, parts[1])

--- a/internal/common/sliceutils/slice.go
+++ b/internal/common/sliceutils/slice.go
@@ -1,7 +1,6 @@
 package sliceutils
 
 import (
-	"log"
 	"time"
 )
 
@@ -110,15 +109,8 @@ func ToInterfaceSlice(slice interface{}) []interface{} {
 }
 
 func AppendAndExtends[T any](slice []T, elems ...T) []T {
-	for i := 0; i < len(elems); i++ {
-		if len(slice)+1 < cap(slice) {
-			log.Println(len(slice), cap(slice), i)
-			slice = slice[:len(slice)+1]
-			log.Println(len(slice), cap(slice), i)
-			slice[len(slice)] = elems[i]
-		} else if cap(slice) < len(slice)+1 {
-			slice = append(slice, elems[i])
-		}
+	for _, e := range elems {
+		slice = append(slice, e)
 	}
 
 	return slice

--- a/internal/common/sqlutils/alias.go
+++ b/internal/common/sqlutils/alias.go
@@ -1,0 +1,6 @@
+package sqlutils
+
+import "regexp"
+
+// AsRegexp matches case-insensitive " AS " with optional whitespace.
+var AsRegexp = regexp.MustCompile(`(?i)\s+as\s+`)

--- a/internal/db/base/utils.go
+++ b/internal/db/base/utils.go
@@ -8,6 +8,8 @@ import (
 	"github.com/faciam-dev/goquent-query-builder/internal/db/interfaces"
 )
 
+var asRegexp = regexp.MustCompile(`(?i)\s+as\s+`)
+
 type SQLUtils struct {
 }
 
@@ -42,9 +44,8 @@ func (s *SQLUtils) EscapeIdentifierAliasedValue(sb []byte, value string) []byte 
 		return sb
 	}
 
-	target := regexp.MustCompile(`(?i)\s+as\s+`)
-	if target.MatchString(value) {
-		parts := target.Split(value, -1)
+	if asRegexp.MatchString(value) {
+		parts := asRegexp.Split(value, -1)
 		sb = s.EscapeIdentifier(sb, parts[0])
 		sb = append(sb, " as "...)
 		sb = s.EscapeIdentifier(sb, parts[1])
@@ -105,9 +106,8 @@ func (s *SQLUtils) GetAlias(value string) string {
 		}
 	}
 
-	target := regexp.MustCompile(`(?i)\s+as\s+`)
-	if target.MatchString(value) {
-		parts := target.Split(value, -1)
+	if asRegexp.MatchString(value) {
+		parts := asRegexp.Split(value, -1)
 		return parts[1]
 	}
 

--- a/internal/db/base/utils.go
+++ b/internal/db/base/utils.go
@@ -1,14 +1,12 @@
 package base
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/faciam-dev/goquent-query-builder/internal/common/consts"
+	"github.com/faciam-dev/goquent-query-builder/internal/common/sqlutils"
 	"github.com/faciam-dev/goquent-query-builder/internal/db/interfaces"
 )
-
-var asRegexp = regexp.MustCompile(`(?i)\s+as\s+`)
 
 type SQLUtils struct {
 }
@@ -44,8 +42,8 @@ func (s *SQLUtils) EscapeIdentifierAliasedValue(sb []byte, value string) []byte 
 		return sb
 	}
 
-	if asRegexp.MatchString(value) {
-		parts := asRegexp.Split(value, -1)
+	if sqlutils.AsRegexp.MatchString(value) {
+		parts := sqlutils.AsRegexp.Split(value, -1)
 		sb = s.EscapeIdentifier(sb, parts[0])
 		sb = append(sb, " as "...)
 		sb = s.EscapeIdentifier(sb, parts[1])
@@ -106,8 +104,8 @@ func (s *SQLUtils) GetAlias(value string) string {
 		}
 	}
 
-	if asRegexp.MatchString(value) {
-		parts := asRegexp.Split(value, -1)
+	if sqlutils.AsRegexp.MatchString(value) {
+		parts := sqlutils.AsRegexp.Split(value, -1)
 		return parts[1]
 	}
 


### PR DESCRIPTION
## Summary
- streamline `AppendAndExtends` implementation
- reuse precompiled regexp in SQL utilities

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6853c701af988328b2a7e8ec4e7daa3e