### PR TITLE
Fix raw placeholder order for overlapping keys

### DIFF
--- a/internal/db/base/where_base.go
+++ b/internal/db/base/where_base.go
@@ -233,6 +233,9 @@ func (wb *WhereBaseBuilder) ProcessRawCondition(sb *[]byte, c structs.Where) []i
 			for key := range c.ValueMap {
 				keys = append(keys, key)
 			}
+			// Sort keys so that overlapping names are replaced starting
+			// with the longer key. This prevents shorter prefixes from
+			// being replaced inside longer keys when building the raw SQL.
 			sort.Slice(keys, func(i, j int) bool {
 				if strings.HasPrefix(keys[i], keys[j]) || strings.HasPrefix(keys[j], keys[i]) {
 					return len(keys[i]) > len(keys[j])

--- a/internal/db/base/where_base.go
+++ b/internal/db/base/where_base.go
@@ -233,7 +233,12 @@ func (wb *WhereBaseBuilder) ProcessRawCondition(sb *[]byte, c structs.Where) []i
 			for key := range c.ValueMap {
 				keys = append(keys, key)
 			}
-			sort.Strings(keys)
+			sort.Slice(keys, func(i, j int) bool {
+				if strings.HasPrefix(keys[i], keys[j]) || strings.HasPrefix(keys[j], keys[i]) {
+					return len(keys[i]) > len(keys[j])
+				}
+				return keys[i] < keys[j]
+			})
 			for _, key := range keys {
 				value := c.ValueMap[key]
 				if value == nil {

--- a/tests/db/base_test.go
+++ b/tests/db/base_test.go
@@ -338,6 +338,28 @@ func TestBaseQueryBuilder(t *testing.T) {
 			},
 		},
 		{
+			"SafeWhereRaw_PrefixKeys",
+			"Where",
+			structs.Query{
+				ConditionGroups: []structs.WhereGroup{
+					{
+						Conditions: []structs.Where{
+							{
+								Raw:      "col = :test AND col2 = :test1",
+								ValueMap: map[string]interface{}{"test": 1, "test1": 2},
+								Operator: consts.LogicalOperator_AND,
+							},
+						},
+						IsDummyGroup: true,
+					},
+				},
+			},
+			QueryBuilderExpected{
+				Expected: " WHERE col = ? AND col2 = ?",
+				Values:   []interface{}{1, 2},
+			},
+		},
+		{
 			"WhereGroup",
 			"WhereGroup",
 			structs.Query{


### PR DESCRIPTION
## Summary
- fix placeholder substitution order for raw where clauses to handle overlapping keys
- add regression test for maps with overlapping keys

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862b49df4d0832890a19286d11fd0db